### PR TITLE
Allow use on Laravel 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/config": "4.0.x",
-        "illuminate/session": "4.0.x",
-        "illuminate/support": "4.0.x",
+        "illuminate/config": "~4",
+        "illuminate/session": "~4",
+        "illuminate/support": "~4",
         "prologue/support": "1.0.x"
     },
     "require-dev": {


### PR DESCRIPTION
Changing the require section from 4.0.x to ~4 for the Illuminate packages is needed in order to use Laravel 4.1
