### PR TITLE
Alert Levels with Arrays

### DIFF
--- a/src/Prologue/Alerts/AlertsMessageBag.php
+++ b/src/Prologue/Alerts/AlertsMessageBag.php
@@ -113,19 +113,19 @@ class AlertsMessageBag extends MessageBag {
 		if (in_array($method, $this->getLevels()))
 		{
 			// Array of alerts
-            if (is_array($parameters[0]))
-            {
-                foreach ($parameters[0] as $parameter)
-                {
-                    $this->add($method, $parameter);
-                }
-                return $this;
-            }
-            // Single alert
-            else
-            {
-                return $this->add($method, $parameters[0]);
-            }
+			if (is_array($parameters[0]))
+			{
+				foreach ($parameters[0] as $parameter)
+				{
+					$this->add($method, $parameter);
+				}
+				return $this;
+			}
+			// Single alert
+			else
+			{
+				return $this->add($method, $parameters[0]);
+			}
 		}
 
 		throw new BadMethodCallException("Method [$method] does not exist.");


### PR DESCRIPTION
I had a use case where I wanted to be able to pass an array of messages to the `Alert::error();` method. This was because I had a MessageBag returned by the Validator and I wanted to set them all as errors without having to loop through each. For example:

```
$validator = Validator::make(Input::all(), $rules);
if ( ! $validator->passes())
{
    Alert::error($validator->messages()->all())->flash();
}
```

To allow for this, I added a bit of code to detect if it the parameter is an array, and if so, loop through and perform the `add()` call on each item. 
