### PR TITLE
adding count()

### DIFF
--- a/src/AlertsMessageBag.php
+++ b/src/AlertsMessageBag.php
@@ -95,12 +95,59 @@ class AlertsMessageBag extends MessageBag
     public function flush($withSession = true)
     {
         $this->messages = [];
-        
+
         if($withSession) {
             $this->session->forget($this->getSessionKey());
         }
 
         return $this;
+    }
+
+    /**
+     * Checks to see if any messages exist.
+     *
+     * @param null $key A specific level you wish to check for.
+     *
+     * @return bool
+     */
+    public function has($level = null)
+    {
+        $alerts = $this->session->get($this->getSessionKey());
+        if(is_null($level) && isset($alerts)) {
+            return true;
+        } else {
+            if(isset($alerts[$level])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the number of messages in the message bag.
+     *
+     * @param null $level A specific level name you wish to count.
+     *
+     * @return int
+     */
+    public function count($level = null)
+    {
+        $alerts = $this->session->get($this->getSessionKey());
+
+        if(is_null($level) && isset($alerts)) {
+            $totalCount = 0;
+            foreach($alerts as $level => $messages) {
+                $totalCount = $totalCount + count($alerts[$level], COUNT_RECURSIVE);
+            }
+            return $totalCount;
+        } else {
+            if(isset($alerts[$level])) {
+                return count($alerts[$level], COUNT_RECURSIVE);
+            }
+        }
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
For #29 

So after further inspection It appears by using the Laravel Messenger back, `has()` already exists and works even with providing a specific level to check for. Unfortunately the built in `count()` only allows you to get total number that are in the MessengerBag not at a 'level' specific count. So I overwrote the original one which will allow you to get the total number of alerts only using the 'levels' specified in the config. But also allows you to enter a specific level such as 'success' to count.

Example Usage:
```php
$alertBag = [
   'success' = [
      'account updated',
      'new password saved',
   ],
   'danger' = [
      'update failed,
   ],
]

Alert::count(); // Will return total count of 3

Alert::count('danger'); // Will return total count under `danger` level, which is 1.

```