### PR TITLE
add support for Laravel 9, remove support for everything else

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,9 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "illuminate/config": "~5|~6|~7|~8",
-        "illuminate/session": "~5|~6|~7|~8",
-        "illuminate/support": "~5|~6|~7|~8"
+        "illuminate/config": "~9",
+        "illuminate/session": "~9",
+        "illuminate/support": "~9"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",
@@ -36,6 +35,11 @@
         "psr-4": {
             "Prologue\\Alerts\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit --testdox",
+        "test-failing": "vendor/bin/phpunit --order-by=defects --stop-on-failure",
+        "test-coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text"
     },
     "minimum-stability": "dev",
     "extra": {

--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,11 @@
-# Alerts for Laravel 5, 6, 7 and 8
+# Alerts for Laravel 5, 6, 7, 8 and 9
 
 [![Build Status](https://img.shields.io/travis/prologuephp/alerts/master.svg?style=flat-square)](https://travis-ci.org/prologuephp/alerts)
-[![Quality Score](https://img.shields.io/scrutinizer/g/prologuephp/alerts.svg?style=flat-square)](https://scrutinizer-ci.com/g/prologuephp/alerts)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](license.md)
 [![Packagist Version](https://img.shields.io/packagist/v/prologue/alerts.svg?style=flat-square)](https://packagist.org/packages/prologue/alerts)
 [![Total Downloads](https://img.shields.io/packagist/dt/prologue/alerts.svg?style=flat-square)](https://packagist.org/packages/prologue/alerts)
 
-Global site messages in Laravel 8, 7, 6 and 5. Helps trigger notification bubbles with a simple API, both in the current page, and in the next page (using flash data).
-
-Created by [Dries Vints](https://github.com/driesvints) - he first got the idea after [a blog post](http://toddish.co.uk/blog/global-site-messages-in-laravel-4/) by [Todd Francis](http://toddish.co.uk/). This package uses much of the concepts of his blog post as well as the concept of alert levels which [Illuminate's Log package](https://github.com/illuminate/log) uses. Maintained by [Cristian Tabacitu](https://github.com/tabacitu) thanks to its use in [Backpack for Laravel](http://backpackforlaravel.com/).
+Global site messages in Laravel 9 - 5. Helps trigger notification bubbles with a simple API, both in the current page, and in the next page (using flash data).
 
 ## Table of Contents
 
@@ -139,6 +136,10 @@ Alert::count('error'); // Will tell you only the amount of errors and exclude an
 ```
 
 If you'd like to learn more ways on how you can display messages, please [take a closer look to Illuminate's `MessageBag` class](https://github.com/illuminate/support/blob/master/MessageBag.php).
+
+## Credits
+
+Created by [Dries Vints](https://github.com/driesvints) - he first got the idea after [a blog post](http://toddish.co.uk/blog/global-site-messages-in-laravel-4/) by [Todd Francis](http://toddish.co.uk/). This package uses much of the concepts of his blog post as well as the concept of alert levels which [Illuminate's Log package](https://github.com/illuminate/log) uses. Maintained by [Cristian Tabacitu](https://github.com/tabacitu) thanks to its use in [Backpack for Laravel](http://backpackforlaravel.com/).
 
 ## Changelog
 

--- a/src/AlertsMessageBag.php
+++ b/src/AlertsMessageBag.php
@@ -131,7 +131,7 @@ class AlertsMessageBag extends MessageBag
      *
      * @return int
      */
-    public function count($level = null)
+    public function count($level = null): int
     {
         $alerts = $this->session->get($this->getSessionKey());
 


### PR DESCRIPTION
Since we remove support for everything else, we might as well tag this as 1.0.0 - long overdue.